### PR TITLE
feat(rec-grid): add vertical page navigation

### DIFF
--- a/src/components/ModalSettings/tab-panes/pane-basic.tsx
+++ b/src/components/ModalSettings/tab-panes/pane-basic.tsx
@@ -147,6 +147,7 @@ export function TabPaneBasic() {
 
           'grid.gridDisplayMode',
           'grid.twoColumnModeAlign',
+          'grid.pagedHorizontal',
         ]}
       >
         <div className={sharedClassNames.settingsLine}>
@@ -195,6 +196,19 @@ export function TabPaneBasic() {
         <div className='flex items-center'>
           网格显示模式
           <GridDisplayModeSwitcher className='ml-xl' />
+        </div>
+
+        <div className={sharedClassNames.settingsLine}>
+          <CheckboxSettingItem
+            configPath='grid.pagedHorizontal'
+            label='整页竖直翻页'
+            tooltip={
+              <>
+                卡片按整屏分页显示, 滚动鼠标滚轮一下翻一整页, 页面之间竖直切换. <br />
+                滚轮向下 = 下一页, 滚轮向上 = 上一页.
+              </>
+            }
+          />
         </div>
       </SettingsGroup>
 

--- a/src/components/RecGrid/index.tsx
+++ b/src/components/RecGrid/index.tsx
@@ -39,6 +39,7 @@ import { getServiceFromRegistry } from '$modules/rec-services/service-map.ts'
 import { settings } from '$modules/settings'
 import { isSafari } from '$ua'
 import { ErrorDetail } from './error-detail'
+import { usePagedHorizontal } from './paged-horizontal'
 import { useSetupGridState } from './rec-grid-state'
 import { setGlobalGridItems } from './unsafe-window-export'
 import { useRefresh } from './useRefresh'
@@ -147,9 +148,8 @@ export const RecGrid = memo(function RecGrid({
   // rec-grid
   const self = useCreation(() => new RecGridSelf(), [])
   const { items, hasMore, refreshError, refreshKey, showSkeleton, loadMoreError } = self.useStore()
-  const { useCustomGrid, gridDisplayMode, enableForceColumn, forceColumnCount, cardMinWidth } = useSnapshot(
-    settings.grid,
-  )
+  const { useCustomGrid, gridDisplayMode, enableForceColumn, forceColumnCount, cardMinWidth, pagedHorizontal } =
+    useSnapshot(settings.grid)
   const { multiSelecting } = useSnapshot(multiSelectStore)
   const unmountedRef = useUnmountedRef()
   useSetupGridState()
@@ -330,6 +330,24 @@ export const RecGrid = memo(function RecGrid({
   // the grid: `.video-grid`
   const gridRef = useRef<HTMLDivElement | null>(null)
 
+  // 整页竖直翻页
+  const pagedViewportRef = useRef<HTMLDivElement | null>(null)
+  const paged = usePagedHorizontal({
+    enabled: pagedHorizontal,
+    viewportRef: pagedViewportRef,
+    fixedColumnCount:
+      gridDisplayMode === EGridDisplayMode.TwoColumnGrid
+        ? 2
+        : enableForceColumn && forceColumnCount
+          ? forceColumnCount
+          : undefined,
+    minColumnWidth: cardMinWidth,
+    itemCount: videoList.length,
+    hasMore,
+    loadMore,
+    infiniteScrollUseWindow,
+  })
+
   const getScrollerRect = useMemoizedFn(() => {
     // use window
     if (infiniteScrollUseWindow) {
@@ -505,7 +523,11 @@ export const RecGrid = memo(function RecGrid({
   )
 
   // it's a `@container` query root
-  const containerClassName = clsx('min-h-100vh @container-inline-size', propContainerClassName)
+  const containerClassName = clsx(
+    pagedHorizontal ? 'min-h-0' : 'min-h-100vh',
+    '@container-inline-size',
+    propContainerClassName,
+  )
 
   type StyleConfig = { className?: string; style?: CSSProperties }
   const gridStyleConfig: StyleConfig = useMemo(() => {
@@ -570,6 +592,53 @@ export const RecGrid = memo(function RecGrid({
 
   const cardBorderCss = useCardBorderCss()
 
+  // 整页竖直翻页渲染
+  const renderPaged = (cards: ReactNode) => {
+    const { pageIndex, rows, cols, pageCount, viewportHeight } = paged
+    const viewportStyle: CSSProperties | undefined = viewportHeight
+      ? { '--paged-viewport-height': `${viewportHeight}px` }
+      : undefined
+    const trackStyle: CSSProperties = {
+      ...gridStyleConfig.style,
+      '--paged-rows': rows,
+      '--paged-cols': cols,
+      '--paged-page-count': pageCount,
+      transform: `translateY(calc(-100% / var(--paged-page-count, 1) * ${pageIndex}))`,
+    }
+    return (
+      <div data-tab={tab} className={containerClassName}>
+        <div ref={pagedViewportRef} className={gridClassNames.pagedHorizontalViewport} style={viewportStyle}>
+          <div
+            data-tab={tab}
+            ref={gridRef}
+            {...gridStyleConfig}
+            className={clsx(gridStyleConfig.className, gridClassNames.pagedHorizontalTrack)}
+            style={trackStyle}
+          >
+            {cards}
+          </div>
+        </div>
+        <div className={gridClassNames.pagedHorizontalIndicator}>
+          <Button
+            size='small'
+            disabled={pageIndex <= 0}
+            onClick={paged.prevPage}
+            icon={<IconParkOutlineRight className='rotate-z-180deg' />}
+          />
+          <span className='mx-10px tabular-nums'>
+            {pageIndex + 1} / {pageCount}
+          </span>
+          <Button
+            size='small'
+            disabled={pageIndex >= pageCount - 1 && !hasMore}
+            onClick={paged.nextPage}
+            icon={<IconParkOutlineRight />}
+          />
+        </div>
+      </div>
+    )
+  }
+
   // 总是 render grid, getColumnCount 依赖 grid columns
   const render = ({ gridChildren, gridSiblings }: { gridChildren?: ReactNode; gridSiblings?: ReactNode } = {}) => {
     return (
@@ -623,6 +692,11 @@ export const RecGrid = memo(function RecGrid({
         />
       )
     }
+  }
+
+  // 整页竖直翻页: 只渲染视频卡片(排除 separator/footer, 它们与分页布局冲突)
+  if (pagedHorizontal) {
+    return renderPaged(videoList.map(renderItem))
   }
 
   // plain dom

--- a/src/components/RecGrid/paged-horizontal.ts
+++ b/src/components/RecGrid/paged-horizontal.ts
@@ -1,0 +1,131 @@
+import { useEventListener, useMemoizedFn } from 'ahooks'
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import { baseDebug } from '$common'
+import { $headerHeight } from '$header'
+
+const debug = baseDebug.extend('components:RecGrid:paged')
+
+// 滚轮翻页节流: 一次连续滚动只翻一页
+const WHEEL_COOLDOWN_MS = 350
+
+// 估算的卡片行高(含 row-gap), 用于推算每页行数
+const ESTIMATED_ROW_HEIGHT = 230
+
+export type UsePagedHorizontalOptions = {
+  enabled: boolean
+  /** viewport 元素, 监听 wheel + 计算可用高度 */
+  viewportRef: RefObject<HTMLElement | null>
+  /** 每页固定列数. 未提供时按 viewport 宽度和 minColumnWidth 自适应计算 */
+  fixedColumnCount?: number
+  /** 自适应列数时的最小列宽 */
+  minColumnWidth: number
+  /** 视频卡片总数(不含 separator) */
+  itemCount: number
+  /** 是否还有更多 */
+  hasMore: boolean
+  /** 触发加载更多 */
+  loadMore: () => void
+  /** 是否使用 window 作为滚动容器(首页), 用于计算可用高度 */
+  infiniteScrollUseWindow: boolean
+}
+
+export type PagedHorizontalState = {
+  /** 当前页码, 0-based */
+  pageIndex: number
+  /** 每页行数 */
+  rows: number
+  /** 每页列数 */
+  cols: number
+  /** 总页数 */
+  pageCount: number
+  /** JS 计算出的视口可用高度(px) */
+  viewportHeight: number
+  goToPage: (page: number) => void
+  prevPage: () => void
+  nextPage: () => void
+}
+
+export function usePagedHorizontal({
+  enabled,
+  viewportRef,
+  fixedColumnCount,
+  minColumnWidth,
+  itemCount,
+  hasMore,
+  loadMore,
+  infiniteScrollUseWindow,
+}: UsePagedHorizontalOptions): PagedHorizontalState {
+  const [pageIndex, setPageIndex] = useState(0)
+  const [rows, setRows] = useState(2)
+  const [cols, setCols] = useState(1)
+  const [viewportHeight, setViewportHeight] = useState(0)
+
+  // 计算每页行数: 视口可用高度 / 估算行高
+  const recompute = useMemoizedFn(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    const availableHeight = infiniteScrollUseWindow
+      ? window.innerHeight - $headerHeight.get() - 55 - 20 // 55: tabbar, 20: 间距
+      : viewport.clientHeight || window.innerHeight - $headerHeight.get() - 55 - 20
+
+    setViewportHeight((prev) => (prev !== availableHeight ? availableHeight : prev))
+
+    const nextRows = Math.max(1, Math.floor(availableHeight / ESTIMATED_ROW_HEIGHT))
+
+    const viewportWidth = viewport.clientWidth || window.innerWidth
+    const nextCols = fixedColumnCount || Math.max(1, Math.floor(viewportWidth / minColumnWidth))
+
+    setRows((prev) => (prev !== nextRows ? nextRows : prev))
+    setCols((prev) => (prev !== nextCols ? nextCols : prev))
+  })
+
+  // resize 时重算
+  useEventListener('resize', recompute, { target: window })
+  useEffect(() => {
+    if (!enabled) return
+    recompute()
+  }, [enabled, fixedColumnCount, itemCount, minColumnWidth, recompute])
+
+  const perPage = Math.max(1, rows * cols)
+  const pageCount = Math.max(1, Math.ceil(itemCount / perPage))
+
+  // 越界纠正(例如刷新后)
+  useEffect(() => {
+    if (pageIndex > pageCount - 1) setPageIndex(Math.max(0, pageCount - 1))
+  }, [pageIndex, pageCount])
+
+  const goToPage = useMemoizedFn((page: number) => {
+    const clamped = Math.max(0, Math.min(page, pageCount - 1))
+    setPageIndex(clamped)
+    // 接近末页时预加载
+    if (hasMore && clamped >= pageCount - 2) loadMore()
+  })
+  const prevPage = useMemoizedFn(() => goToPage(pageIndex - 1))
+  const nextPage = useMemoizedFn(() => goToPage(pageIndex + 1))
+
+  // wheel 翻页
+  const lastWheelAt = useRef(0)
+  useEventListener(
+    'wheel',
+    (e: WheelEvent) => {
+      if (!enabled) return
+      e.preventDefault()
+      const now = Date.now()
+      if (now - lastWheelAt.current < WHEEL_COOLDOWN_MS) return
+      if (Math.abs(e.deltaY) < 4) return
+      lastWheelAt.current = now
+      debug('wheel deltaY=%s pageIndex=%s', e.deltaY, pageIndex)
+      if (e.deltaY > 0) nextPage()
+      else prevPage()
+    },
+    { target: viewportRef, passive: false },
+  )
+
+  // 切 tab/刷新后回到第一页
+  useEffect(() => {
+    if (itemCount === 0) setPageIndex(0)
+  }, [itemCount])
+
+  return { pageIndex, rows, cols, pageCount, viewportHeight, goToPage, prevPage, nextPage }
+}

--- a/src/components/RecGrid/video-grid.module.scss
+++ b/src/components/RecGrid/video-grid.module.scss
@@ -88,3 +88,36 @@
 .narrow-mode {
   --col: 2 !important;
 }
+
+//
+// 整页竖直翻页
+//
+.paged-horizontal-viewport {
+  position: relative;
+  width: 100%;
+  // 视口高度由 JS 计算后通过 --paged-viewport-height 传入
+  height: var(--paged-viewport-height, 80vh);
+  overflow: hidden;
+}
+
+.paged-horizontal-track {
+  // 覆盖默认 grid: 行优先填充, 固定每页列数.
+  // 总行数 = 页数 * 每页行数, 每个自动行高 = 单页高度 / 每页行数.
+  width: 100%;
+  height: calc(var(--paged-page-count, 1) * 100%);
+  grid-auto-flow: row;
+  grid-template-rows: unset;
+  grid-template-columns: repeat(var(--paged-cols, 1), minmax(0, 1fr));
+  grid-auto-rows: calc(100% / var(--paged-page-count, 1) / var(--paged-rows, 1));
+  align-content: start;
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+
+.paged-horizontal-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 0;
+  user-select: none;
+}

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -67,6 +67,9 @@ export const initialSettings = {
 
     // 卡片最小宽度, 虽然是卡片, 但其实是网格布局
     cardMinWidth: 320,
+
+    // 整页竖直翻页: 卡片按整屏分页, 滚轮一下翻一整页, 页面之间竖直切换
+    pagedHorizontal: false,
   },
 
   /**


### PR DESCRIPTION
## Summary
- add a paged recommendation grid mode that displays a full viewport of cards per page
- switch page transitions to vertical movement while preserving row/column based page sizing
- expose the paged mode in basic grid settings

## Verification
- pnpm _typecheck

## Notes
- local pre-commit hook could not run because oxfmt requires Node.js ^20.19.0 || >=22.18.0, while this environment has Node.js v22.17.0